### PR TITLE
Stop creating extraneous timeseries files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ group :development do
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
-  gem 'spring'
+  # gem 'spring'
   gem 'listen'
 end
 
@@ -117,5 +117,7 @@ gem 'capybara', '~> 3.33'
 # gem "debase", "~> 0.2.4"
 
 # gem "ruby-debug-ide", "~> 0.7.2"
+
+gem "fakefs", require: false
 
 gem "lograge-sql", "~> 2.0"

--- a/app/controllers/chaos_api/v6/time_series_controller.rb
+++ b/app/controllers/chaos_api/v6/time_series_controller.rb
@@ -50,8 +50,6 @@ module ChaosApi
         # @response_status = :created
         @response_status = :ok
 
-        ap time_series
-
         if params[:points]
           append_tsv_from_json(time_series)
         elsif params[:file]
@@ -137,8 +135,6 @@ module ChaosApi
         study_definition_id = @chaos_session.study_definition_id
         phase_definition_id = @chaos_session.phase_definition_id
 
-        puts "\n\n\n #{@series_type}"
-
         unprocessable_entity "invalid series type #{@series_type}" unless StudyResult::TimeSeries::SERIES_TYPES.include? @series_type.to_sym
 
         schema = case @series_type
@@ -173,7 +169,7 @@ module ChaosApi
         @series_type = (params[:seriesType] || 'webgazer').to_sym
         @header_set = HEADERS_SET[@series_type]
 
-        params.permit(:format, :sessionGUID, :data, :series_type, :file, points: @header_set)
+        params.permit(:format, :sessionGUID, :data, :seriesType, :content, :series_type, :file, points: @header_set)
       end
     end
   end

--- a/app/models/chaos/chaos_session.rb
+++ b/app/models/chaos/chaos_session.rb
@@ -38,11 +38,11 @@ module Chaos
       experiment = StudyResult::Experiment.where(
         study_result_id: study_result.id,
         protocol_user_id: protocol_user.id
-      ).first_or_initialize do |e|
+      ).first_or_initialize.tap do |new_experiment|
         # we need to have a real experiment with an ID for later
-        e.started_at = DateTime.now
-        e.custom_parameters = custom_parameters.as_json
-        e.save!
+        new_experiment.started_at = DateTime.now
+        new_experiment.custom_parameters = custom_parameters.as_json
+        new_experiment.save!
       end
 
       if !experiment.current_stage

--- a/app/uploaders/time_series_uploader.rb
+++ b/app/uploaders/time_series_uploader.rb
@@ -61,7 +61,7 @@ class TimeSeriesUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[csv tsv json gz]
   end
 end

--- a/test/controllers/ChaosApi/V6/time_series_controller_test.rb
+++ b/test/controllers/ChaosApi/V6/time_series_controller_test.rb
@@ -7,35 +7,39 @@ require 'fakefs/safe'
 module ChaosApi
   module V6
     class TimeSeriesControllerTest < ActionDispatch::IntegrationTest
+      def initialize_study_result
+        @study_definition = study_definition(:learning_study)
+        @protocol_definition = protocol_definition(:learning_study)
+
+        @phase_definition = phase_definition(:learning_study)
+
+        @trial_definition = trial_definition(:learning_study_1)
+        @user = user(:registered_user)
+
+        @stage = study_result_stage(:learning_study_1)
+
+        session_params = {
+          user_id: @user.id,
+          session_guid: SecureRandom.uuid,
+          url: 'foo',
+          expires_at: Date.today + 1.day,
+          study_definition_id: @study_definition.id,
+          protocol_definition_id: @protocol_definition.id,
+          protocol_user_id: nil,
+          phase_definition_id: @phase_definition.id,
+          trial_definition_id: @trial_definition.id,
+          stage_id: @stage.id,
+          preview: false
+        }
+
+        @chaos_session = Chaos::ChaosSession.new(session_params)
+        @chaos_session.save!
+      end
+
       test 'face_landmark json single row' do
         as_user(user(:registered_user)) do |headers|
 
-          @study_definition = study_definition(:learning_study)
-          @protocol_definition = protocol_definition(:learning_study)
-
-          @phase_definition = phase_definition(:learning_study)
-
-          @trial_definition = trial_definition(:learning_study_1)
-          @user = user(:registered_user)
-
-          @stage = study_result_stage(:learning_study_1)
-
-          session_params = {
-            user_id: @user.id,
-            session_guid: SecureRandom.uuid,
-            url: 'foo',
-            expires_at: Date.today + 1.day,
-            study_definition_id: @study_definition.id,
-            protocol_definition_id: @protocol_definition.id,
-            protocol_user_id: nil,
-            phase_definition_id: @phase_definition.id,
-            trial_definition_id: @trial_definition.id,
-            stage_id: @stage.id,
-            preview: false
-          }
-
-          @chaos_session = Chaos::ChaosSession.new(session_params)
-          @chaos_session.save!
+          initialize_study_result
 
           post chaos_api_v6_time_series_url, params: { sessionGUID: @chaos_session.session_guid, seriesType: 'face_landmark', data: [{ test: 'this' }]}, as: :json, headers: headers
           assert_response :success
@@ -43,7 +47,24 @@ module ChaosApi
           time_series = StudyResult::TimeSeries.last
           assert time_series.present?
           # TODO: check path format?
-          assert File.read(time_series.file.path) == { test: 'this' }.to_json
+          assert_equal File.read(time_series.file.path).strip, { test: 'this' }.to_json
+        end
+      end
+
+      test 'reuses same time series' do
+
+        as_user(user(:registered_user)) do |headers|
+          initial_time_series_ids = Set.new(StudyResult::TimeSeries.all.pluck(:id))
+          initialize_study_result
+
+          post chaos_api_v6_time_series_url, params: { sessionGUID: @chaos_session.session_guid, seriesType: 'face_landmark', data: [{ test: 'this' }]}, as: :json, headers: headers
+          assert_response :success
+          assert_equal((Set.new(StudyResult::TimeSeries.all.pluck(:id)) - initial_time_series_ids).size, 1)
+
+          post chaos_api_v6_time_series_url, params: { sessionGUID: @chaos_session.session_guid, seriesType: 'face_landmark', data: [{ test: 'this' }]}, as: :json, headers: headers
+          assert_response :success
+
+          assert_equal((Set.new(StudyResult::TimeSeries.all.pluck(:id)) - initial_time_series_ids).size, 1)
         end
       end
 

--- a/test/controllers/api/v1/time_series_controller_test.rb
+++ b/test/controllers/api/v1/time_series_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/unit'
+require 'mocha/minitest'
+require 'minitest/mock'
+
+module Api
+  module V1
+    class TimeSeriesControllerTest < ActionDispatch::IntegrationTest
+      test 'return 200' do
+        as_user(user(:admin)) do |headers|
+          series = study_result_time_series(:learning_time_series_1)
+          study_result = study_result_study_result(:learning_study_1)
+          get api_v1_study_result_time_series_url(id: series.id, study_result_id: study_result.id), params: {  }, as: :json, headers: headers
+          assert_response :ok, 'Request failed'
+        end
+      end
+
+      test 'return 403 without authorization' do
+        as_user(user(:admin)) do |headers|
+          series = study_result_time_series(:learning_time_series_1)
+          study_result = study_result_study_result(:learning_study_1)
+          get api_v1_study_result_time_series_url(id: series.id, study_result_id: study_result.id), params: {  }, as: :json
+          assert_response :unauthorized, 'Response was not unauthorized'
+        end
+      end
+    end
+  end
+end
+

--- a/test/fixtures/study_result/study_result.yml
+++ b/test/fixtures/study_result/study_result.yml
@@ -1,1 +1,2 @@
---- {}
+learning_study_1:
+  study_definition: learning_study

--- a/test/fixtures/study_result/time_series.yml
+++ b/test/fixtures/study_result/time_series.yml
@@ -1,1 +1,4 @@
---- {}
+learning_time_series_1:
+  study_definition: learning_study
+  protocol_definition: learning_study
+  phase_definition: learning_study

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,10 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'dotenv'
 Dotenv.load('.env.test.local')
-require File.expand_path('../config/environment', __dir__)
+
+require_relative '../config/environment'
+require 'rails/test_help'
+
 require 'minitest/autorun'
 require 'rails/test_help'
 require 'mocha/minitest'


### PR DESCRIPTION
The extra time series seem related to 3 separate things.

1. The testcase for landmarker has `Monitor` components. These cause Mouse tracking. To remove mouse tracking, simply remove these components.
2. Potential race condition in creating the new time series for a stage. This is exacerbated by the client sending datapoints as they're ready. The time span for the race condition has been significantly reduced on the server and the data points sending from the client is now debounced.
3. Some of the mouse DataPoint endpoints were being sent from the client without an appropriate `seriesType` so it got the default, `webgazer`