### PR TITLE
Add server-side search, sort, and role filter for admin users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -66,17 +66,23 @@ module Api
       end
 
       def index
-        if !params.key?(:query) || (params[:query].length < 3)
-          if params.key?(:q)
-            username_query = { username: /#{params[:q]}/i }
-            email_query = { email: params[:q] }
-            @all_users = User.or(username_query, email_query).all
-          else
-            @all_users = User.all
-          end
-        else
-          @all_users = User.where(email: params[:query]).or(User.where(username: params[:query]))
+        @all_users = User.all
+
+        # Search by username or email
+        if params[:q].present?
+          query = params[:q].to_s[0..99]
+          escaped_query = query.gsub(/([%_\\])/, '\\\\\1')
+          @all_users = @all_users.where('username ILIKE ? OR email ILIKE ?', "%#{escaped_query}%", "%#{escaped_query}%")
         end
+
+        # Role filter
+        @all_users = @all_users.where(role: params[:role]) if params[:role].present?
+
+        # Sorting
+        sortable_columns = %w[username email role created_at id]
+        sort_column = params[:sort_column].presence_in(sortable_columns) || 'created_at'
+        sort_direction = params[:sort_direction] == 'asc' ? 'asc' : 'desc'
+        @all_users = @all_users.order("#{sort_column} #{sort_direction}")
 
         authorize! :read, User
 
@@ -87,7 +93,6 @@ module Api
                              .per(page_params[:page_size])
         end
 
-        # render json: { page: page_params[:page], total_items: @all_users.size }
         set_pagination_headers @users, @all_users, page_params
 
         render json: @users
@@ -108,9 +113,13 @@ module Api
         render json: @user
       end
 
-      def edit; super; end
+      def edit
+        super
+      end
 
-      def destroy; super; end
+      def destroy
+        super
+      end
 
       private
 

--- a/app/controllers/concerns/pagination_header_links.rb
+++ b/app/controllers/concerns/pagination_header_links.rb
@@ -37,5 +37,6 @@ module PaginationHeaderLinks
     headers['Link'] = pagination_links.join(', ') unless pagination_links.empty?
     headers['Total'] = root_scope.size if root_scope.present?
     headers['PageSize'] = options[:page_size] if options[:page_size].present?
+    headers['TotalPages'] = paginated_scope.total_pages
   end
 end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -33,7 +33,8 @@ module Api::V1
     test 'admin can create any kind of user' do
       %i[investigator admin registered_user].each do |role|
         as_user(user(:admin)) do |headers|
-          post users_url, params: { user: { email: "new-#{role}@elicit.com", anonymous: false, role: role.to_s, password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
+          post users_url,
+               params: { user: { email: "new-#{role}@elicit.com", anonymous: false, role: role.to_s, password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
           assert_response :created, "Admin failed to create #{role}"
         end
       end
@@ -42,7 +43,8 @@ module Api::V1
     test 'investigator cannot create admin or other investigator' do
       %i[investigator admin].each do |role|
         as_user(user(:investigator)) do |headers|
-          post users_url, params: { user: { email: 'admin2@elicit.com', anonymous: false, role: role.to_s, password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
+          post users_url,
+               params: { user: { email: 'admin2@elicit.com', anonymous: false, role: role.to_s, password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
           assert_response :forbidden, "Failed to disallow create of #{role} by investigator"
         end
       end
@@ -51,7 +53,8 @@ module Api::V1
     test 'investigator or admin can create registered user' do
       %i[investigator admin].each do |role|
         as_user(user(role)) do |headers|
-          post users_url, params: { user: { email: "newby#{role}@elicit.com", anonymous: false, role: 'registered_user', password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
+          post users_url,
+               params: { user: { email: "newby#{role}@elicit.com", anonymous: false, role: 'registered_user', password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
           assert_response :created, "#{role} failed to create registered user"
         end
       end
@@ -60,10 +63,210 @@ module Api::V1
     test 'registered user cannot create any user' do
       %i[investigator admin registered_user].each do |role|
         as_user(user(:registered_user)) do |headers|
-          post users_url, params: { user: { email: 'noouser@elicit.com', anonymous: false, role: role.to_s, password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
+          post users_url,
+               params: { user: { email: 'noouser@elicit.com', anonymous: false, role: role.to_s, password: 'abcd12_', password_confirmation: 'abcd12_' } }, as: :json, headers: headers
           assert_response :forbidden
         end
       end
+    end
+
+    test 'index returns paginated users with correct headers' do
+      as_user(user(:admin)) do |headers|
+        get users_url, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert body.is_a?(Array)
+        assert_response_header_present 'Total'
+        assert_response_header_present 'PageSize'
+        assert_response_header_present 'TotalPages'
+      end
+    end
+
+    test 'index excludes admin and investigator roles for non-admin user' do
+      as_user(user(:investigator)) do |headers|
+        get users_url, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        roles = body.map { |u| u['role'] }
+        assert_not_includes roles, 'admin'
+        assert_not_includes roles, 'investigator'
+      end
+    end
+
+    test 'index includes all roles for admin user' do
+      as_user(user(:admin)) do |headers|
+        get users_url, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        roles = body.map { |u| u['role'] }
+        assert_includes roles, 'admin'
+        assert_includes roles, 'investigator'
+      end
+    end
+
+    test 'index searches by username' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { q: 'subject1' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 1, body.size
+        assert_equal 'subject1', body[0]['username']
+      end
+    end
+
+    test 'index searches by email' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { q: 'subject2@elicit.com' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 1, body.size
+        assert_equal 'subject2', body[0]['username']
+      end
+    end
+
+    test 'index search is case-insensitive' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { q: 'SUBJECT1' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 1, body.size
+        assert_equal 'subject1', body[0]['username']
+      end
+    end
+
+    test 'index search escapes ILIKE wildcard characters' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { q: 'subject%' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 0, body.size
+      end
+    end
+
+    test 'index search escapes underscore wildcard character' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { q: 'subject_' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 0, body.size
+      end
+    end
+
+    test 'index search truncates long query strings' do
+      as_user(user(:admin)) do |headers|
+        long_query = 'a' * 200
+        get users_url, params: { q: long_query }, headers: headers
+        assert_response :success
+      end
+    end
+
+    test 'index filters by role' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { role: 'registered_user' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        roles = body.map { |u| u['role'] }
+        assert(roles.all? { |r| r == 'registered_user' })
+      end
+    end
+
+    test 'index sorts by username ascending' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { sort_column: 'username', sort_direction: 'asc' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        usernames = body.map { |u| u['username'] }
+        assert_equal usernames, usernames.sort
+      end
+    end
+
+    test 'index sorts by username descending' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { sort_column: 'username', sort_direction: 'desc' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        usernames = body.map { |u| u['username'] }
+        assert_equal usernames, usernames.sort.reverse
+      end
+    end
+
+    test 'index sorts by email ascending' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { sort_column: 'email', sort_direction: 'asc' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        emails = body.map { |u| u['email'] }
+        assert_equal emails, emails.sort
+      end
+    end
+
+    test 'index sorts by role' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { sort_column: 'role', sort_direction: 'asc' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        roles = body.map { |u| u['role'] }
+        assert_equal roles, roles.sort
+      end
+    end
+
+    test 'index defaults to created_at descending sort' do
+      as_user(user(:admin)) do |headers|
+        get users_url, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        created_ats = body.map { |u| u['created_at'] }
+        assert_equal created_ats, created_ats.sort.reverse
+      end
+    end
+
+    test 'index ignores invalid sort column' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { sort_column: 'password' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        created_ats = body.map { |u| u['created_at'] }
+        assert_equal created_ats, created_ats.sort.reverse
+      end
+    end
+
+    test 'index combines search and sort' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { q: 'subject', sort_column: 'username', sort_direction: 'desc' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        usernames = body.map { |u| u['username'] }
+        assert(usernames.all? { |u| u.include?('subject') })
+        assert_equal usernames, usernames.sort.reverse
+      end
+    end
+
+    test 'index combines role filter and sort' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { role: 'registered_user', sort_column: 'email', sort_direction: 'asc' }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        roles = body.map { |u| u['role'] }
+        assert(roles.all? { |r| r == 'registered_user' })
+        emails = body.map { |u| u['email'] }
+        assert_equal emails, emails.sort
+      end
+    end
+
+    test 'index paginates results' do
+      as_user(user(:admin)) do |headers|
+        get users_url, params: { page_size: 1 }, headers: headers
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 1, body.size
+        assert_equal '1', response.headers['PageSize']
+      end
+    end
+
+    private
+
+    def assert_response_header_present(header_name)
+      assert response.headers[header_name], "Expected response header '#{header_name}' to be present"
     end
   end
 end


### PR DESCRIPTION
## Summary
PR #22 (feature/admin-users-search-sort-pagination) was merged with frontend changes for search, sort, and pagination on the UserManagement page, but the corresponding server-side changes were accidentally omitted.

This PR adds the missing backend support:
- **Search**: PostgreSQL ILIKE queries for username/email with wildcard character escaping and query truncation
- **Role filter**: Filter users by role via `role` query parameter
- **Sorting**: Sort by username, email, role, created_at, or id with direction control
- **Tests**: 17 new test cases covering search, filter, sort, pagination, and combinations

### Query parameters supported
- `q` - search query (username or email, case-insensitive)
- `role` - filter by role
- `sort_column` - column to sort by (allowlisted)
- `sort_direction` - `asc` or `desc`
- `page` / `page_size` - pagination