### PR TITLE
Reduce Solid Queue worker polling frequency and silence polling logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,7 @@ Rails.application.configure do
     config.active_job.queue_adapter = :solid_queue
     config.solid_queue.connects_to = { database: { writing: :queue } }
     config.active_job.queue_name_prefix = "elicit_#{Rails.env}"
+    config.solid_queue.silence_polling = true
   end
 
   config.action_mailer.perform_caching = false

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -6,7 +6,7 @@ default: &default
     - queues: "*"
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
+      polling_interval: 1
 
 development:
   <<: *default


### PR DESCRIPTION
This PR addresses the high CPU usage observed from Solid Queue workers by:

- Increasing the worker polling interval from 0.1s to 1s (default was already 1s for dispatchers)
- Enabling silence_polling to reduce log noise

We do not require sub-second job latency for background work, and the aggressive 0.1s interval contributes unnecessary DB load and log volume when queues are idle.

Related issues: #<will add after creating issues>