### PR TITLE
fix: study list skipping top studies

### DIFF
--- a/app/controllers/api/v1/study_definitions_controller.rb
+++ b/app/controllers/api/v1/study_definitions_controller.rb
@@ -36,7 +36,7 @@ module Api
           root_scope = StudyDefinition.where(principal_investigator_user_id: current_api_user.id)
         end
 
-        resources = root_scope.includes(query_includes).joins(:principal_investigator).order(created_at: :desc)
+        resources = root_scope.preload(query_includes).joins(:principal_investigator).order(created_at: :desc)
 
         unless page_params.nil?
           resources = resources.page(page_params[:page])

--- a/app/javascript/api/elicit/paginatedRestApi.js
+++ b/app/javascript/api/elicit/paginatedRestApi.js
@@ -82,6 +82,7 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
     sortColumn: 'created_at',
     sortDirection: 'desc',
     roleFilter: null,
+    appendNextPage: false,
   });
 
   const initialState = makePaginationDefaultState();
@@ -96,6 +97,9 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
         case api.events[storeName].setPageAsLoading:
           return { ...state, loading: true, syncing: true, sync: false };
 
+        case api.events[storeName].setAppendNextPage:
+          return { ...state, appendNextPage: true };
+
         case api.events[storeName].setSearchParams:
           return {
             ...state,
@@ -103,6 +107,7 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
             sortColumn: action.sortColumn ?? state.sortColumn,
             sortDirection: action.sortDirection ?? state.sortDirection,
             roleFilter: action.roleFilter ?? state.roleFilter,
+            appendNextPage: action.appendNextPage ?? false,
           };
 
         case api.events[storeName].reloadWithParams:
@@ -115,12 +120,15 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
             currentPage: action.currentPage ?? 1,
             loading: true,
             syncing: true,
+            appendNextPage: false,
           };
 
         case api.events[entityPluralName].actionSuccess:
           return {
             ...state,
-            data: action.data.data,
+            data: state.appendNextPage
+              ? state.data.concat(action.data.data)
+              : action.data.data,
             currentPage: action.request.pathvars?.page ?? state.currentPage,
             totalItems: action.data.totalItems,
             totalPages: action.data.totalPages ?? state.totalPages,
@@ -128,6 +136,7 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
             loading: false,
             syncing: false,
             sync: true,
+            appendNextPage: false,
           };
 
         case `@@redux-api@${entityPluralName}_append_${entityName}`:
@@ -180,6 +189,7 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
       setPageAsLoading: `@redux-api@paginated@${entityPluralName}@setPageAsLoading`,
       setSearchParams: `@redux-api@paginated@${entityPluralName}@setSearchParams`,
       reloadWithParams: `@redux-api@paginated@${entityPluralName}@reloadWithParams`,
+      setAppendNextPage: `@redux-api@paginated@${entityPluralName}@setAppendNextPage`,
     };
   }
 
@@ -218,8 +228,8 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
           const paginatedState = state[storeName];
           if (paginatedState.loading) return;
           if (page < 1 || page > paginatedState.totalPages) return;
+          dispatch(api.actions[storeName].setSearchParams({ appendNextPage: false }));
           dispatch(api.actions[storeName].setPageAsLoading());
-          dispatch(api.actions[storeName].setSearchParams({}));
           dispatch(
             api.actions[entityPluralName].force({ ...buildQueryParams({ ...paginatedState, currentPage: page }) }),
           );
@@ -230,10 +240,11 @@ export function makePaginatedApi(restApiDefinition, entityName, entityPluralName
         return function (dispatch, getState) {
           const state = getState();
           const paginatedState = state[storeName];
-          const nextPage = paginatedState.currentPage + 1;
+          const nextPage = paginatedState.data.length === 0 ? 1 : paginatedState.currentPage + 1;
           if (paginatedState.loading) return;
           if (paginatedState.totalPages > 0 && nextPage > paginatedState.totalPages) return;
           dispatch(api.actions[storeName].setPageAsLoading());
+          dispatch({ type: api.events[storeName].setAppendNextPage });
           dispatch(
             api.actions[entityPluralName].force({ ...buildQueryParams({ ...paginatedState, currentPage: nextPage }) }),
           );

--- a/test/controllers/api/v1/study_definitions_controller_test.rb
+++ b/test/controllers/api/v1/study_definitions_controller_test.rb
@@ -88,5 +88,52 @@ module Api::V1
 
       assert_response :success
     end
+
+    test 'index returns studies ordered by created_at desc' do
+      old_study = StudyDefinition.create!(title: 'Old Study', principal_investigator: user(:admin), created_at: 10.days.ago)
+      new_study = StudyDefinition.create!(title: 'New Study', principal_investigator: user(:admin), created_at: 1.day.ago)
+
+      get api_v1_study_definitions_url, as: :json, headers: @headers
+      assert_response :success
+
+      studies = JSON.parse(response.body)
+      titles = studies.map { |s| s['title'] }
+      assert titles.index('New Study') < titles.index('Old Study'), 'Expected new study to appear before old study'
+    end
+
+    test 'index paginates without overlap' do
+      # Create enough studies to exceed default page size of 20
+      25.times do |i|
+        StudyDefinition.create!(title: "Paginated Study #{i}", principal_investigator: user(:admin), created_at: (i + 1).days.ago)
+      end
+
+      get api_v1_study_definitions_url, params: { page: 1, page_size: 10 }, as: :json, headers: @headers
+      assert_response :success
+      page1 = JSON.parse(response.body)
+      assert_equal 10, page1.length
+
+      get api_v1_study_definitions_url, params: { page: 2, page_size: 10 }, as: :json, headers: @headers
+      assert_response :success
+      page2 = JSON.parse(response.body)
+      assert_equal 10, page2.length
+
+      page1_ids = page1.map { |s| s['id'] }
+      page2_ids = page2.map { |s| s['id'] }
+      assert_empty page1_ids & page2_ids, 'Expected pages to not overlap'
+    end
+
+    test 'index does not duplicate studies with multiple protocols' do
+      study = StudyDefinition.create!(title: 'Multi-Protocol Study', principal_investigator: user(:admin))
+      ProtocolDefinition.create!(name: 'Protocol 1', study_definition: study, active: true)
+      ProtocolDefinition.create!(name: 'Protocol 2', study_definition: study, active: true)
+
+      get api_v1_study_definitions_url, as: :json, headers: @headers
+      assert_response :success
+
+      studies = JSON.parse(response.body)
+      ids = studies.map { |s| s['id'] }
+      assert_equal ids.uniq.length, ids.length, 'Expected no duplicate studies in index'
+      assert_includes ids, study.id
+    end
   end
 end


### PR DESCRIPTION
## Problem

Users reported that newly added studies were missing from the study list after a page refresh. The newest ("top") studies were consistently skipped.

## Root Cause

1. **Frontend off-by-one pagination**:  in  always requested . Since  defaulted to , the very first API call asked for **page 2**. Studies are sorted , so the newest studies lived on page 1 and were never fetched.

2. **Reducer overwrote data**: On every , the reducer replaced the entire  array instead of appending new pages. This broke infinite-scroll accumulation.

3. **Backend row duplication**:  used , which generated s. Studies with multiple protocols/phases produced duplicate rows, causing / pagination to skip or duplicate distinct studies.

## Changes

- **Frontend** ():
  -  now requests page  when the list is empty, and  otherwise.
  - Added  state flag. The  reducer appends new page data when the flag is set, and replaces data on direct navigation/reloads.

- **Backend** ():
  - Changed  to  to avoid row duplication from joins.

- **Tests** ():
  - Added tests for ordering, pagination without overlap, and no duplicates with multiple protocols.

## Verification

All backend tests pass:
